### PR TITLE
Integrate Prettier into frontend build for automatic code formatting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,18 @@ RUN mkdir -p logs && chown codedox:codedox logs
 COPY --chown=root:root docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Note: VS Code language detection has been removed in favor of LLM-based detection
+# Install Node.js and npm for frontend dependencies (including Prettier)
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install frontend dependencies (including Prettier for code formatting)
+WORKDIR /app/frontend
+COPY --chown=codedox:codedox frontend/package*.json ./
+RUN npm install && \
+    chown -R codedox:codedox node_modules
+
+WORKDIR /app
 
 # Install Playwright browsers as root with proper setup
 USER root

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "postcss": "^8.4.32",
+    "prettier": "^3.2.5",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"

--- a/setup.sh
+++ b/setup.sh
@@ -60,8 +60,15 @@ echo ""
 echo "🌐 Installing Playwright browsers..."
 crawl4ai-setup
 
-# Note: Prettier is now installed via pip as part of requirements.txt
-# VS Code language detection has been removed in favor of LLM-based detection
+# Install frontend dependencies (including Prettier for code formatting)
+if [ -d "frontend" ]; then
+    echo ""
+    echo "📦 Installing frontend dependencies..."
+    cd frontend
+    npm install
+    cd ..
+    echo "✅ Frontend dependencies installed"
+fi
 
 
 # Copy environment file if it doesn't exist

--- a/src/crawler/code_formatter.py
+++ b/src/crawler/code_formatter.py
@@ -60,7 +60,7 @@ class CodeFormatter:
         self.prettier_path = self._find_prettier_path()
         self.prettier_available = self.prettier_path is not None
         if not self.prettier_available:
-            logger.warning("Prettier not found. Install it globally with 'npm install -g prettier'")
+            logger.warning("Prettier not found. Run 'npm install' in the frontend directory to enable JavaScript/TypeScript formatting")
     
     def _find_prettier_path(self) -> Optional[str]:
         """Find Prettier executable in various locations with security validation."""
@@ -70,7 +70,9 @@ class CodeFormatter:
         
         # Check common locations
         possible_paths = [
-            # Primary: System PATH
+            # Primary: Frontend node_modules (where we install it)
+            os.path.join(project_root, "frontend", "node_modules", ".bin", "prettier"),
+            # Secondary: System PATH
             "prettier",
             # npm global on Unix
             "/usr/local/bin/prettier",


### PR DESCRIPTION
- Add prettier to frontend package.json as dev dependency
- Update code formatter to check frontend/node_modules/.bin/prettier first
- Modify setup.sh to install frontend dependencies including prettier
- Update Dockerfile to install Node.js and frontend dependencies
- Ensure prettier is available in both local and Docker environments