### PR TITLE
Fix recrawl snippet deletion and force regeneration

### DIFF
--- a/src/crawler/crawl_manager.py
+++ b/src/crawler/crawl_manager.py
@@ -255,6 +255,11 @@ class CrawlManager:
         base_snippet_count, total_snippets = self._initialize_crawl_tracking(job_id)
         logger.info(f"[SNIPPET_COUNT] Starting single crawl for job {job_id} with base count: {base_snippet_count}")
 
+        # Get job config for metadata (including ignore_hash)
+        job_data = self.job_manager.get_job_status(job_id)
+        logger.info(f"DEBUG: job_data config = {job_data.get('config') if job_data else 'No job data'}")
+        job_config = job_data.get("config", {}) if job_data else {}
+
         # Process each URL
         for url in config.start_urls:
             if processed_count >= config.max_pages:
@@ -270,8 +275,9 @@ class CrawlManager:
 
             # Crawl single page
             logger.info(f"DEBUG: About to call crawl_page for single page {url}")
+            logger.info(f"DEBUG: job_config before crawl_page = {job_config}")
             results = await self.page_crawler.crawl_page(
-                url, job_id, 0, 0, None, self.progress_tracker
+                url, job_id, 0, 0, job_config, self.progress_tracker
             )
 
             if results:

--- a/src/crawler/page_crawler.py
+++ b/src/crawler/page_crawler.py
@@ -162,7 +162,8 @@ class PageCrawler:
                             extraction_semaphore,
                             job_id,
                             depth,
-                            progress_tracker
+                            progress_tracker,
+                            job_config
                         )
                     )
                     workers.append(worker)
@@ -320,7 +321,8 @@ class PageCrawler:
         semaphore: asyncio.Semaphore,
         job_id: str,
         depth: int,
-        progress_tracker: Optional[Any] = None
+        progress_tracker: Optional[Any] = None,
+        job_config: Optional[Dict[str, Any]] = None
     ) -> None:
         """Worker that extracts code from markdown content."""
         logger.info(f"Extraction worker started for job {job_id}")
@@ -332,7 +334,7 @@ class PageCrawler:
                 
                 # Process the crawl result (semaphore used internally for LLM calls)
                 processed_result = await self._process_crawl_result_with_html_extraction(
-                    result, job_id, depth, llm_semaphore=semaphore
+                    result, job_id, depth, llm_semaphore=semaphore, job_config=job_config
                 )
                 
                 if processed_result:
@@ -437,13 +439,15 @@ class PageCrawler:
         
         # Check if we should ignore hash (for regeneration)
         ignore_hash = False
+        logger.debug(f"DEBUG: job_config = {job_config}")
         if job_config and isinstance(job_config, dict):
             job_metadata = job_config.get('metadata', {})
             ignore_hash = job_metadata.get('ignore_hash', False)
+            logger.info(f"DEBUG: job_metadata = {job_metadata}, ignore_hash = {ignore_hash}")
             if ignore_hash:
                 logger.info(f"Ignoring content hash for {result.url} - forcing regeneration")
         
-        # Check if content has changed (skip if ignore_hash is True)
+        # Check if content has changed (skip ONLY if ignore_hash is False)
         if not ignore_hash:
             with self.db_manager.session_scope() as session:
                 from ..database import check_content_hash
@@ -469,6 +473,9 @@ class PageCrawler:
                             **page_metadata  # Include all extracted metadata
                         }
                     )
+        else:
+            # When ignore_hash is True, we force extraction even if content hasn't changed
+            logger.info(f"Force regeneration enabled for {result.url}, proceeding with extraction despite content hash")
         
         # Content changed or new - extract code blocks from HTML
         logger.info(f"Content changed/new for {result.url}, performing HTML extraction")

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -78,7 +78,8 @@ class CrawlJob(Base):  # type: ignore[misc,valid-type]
             'failed_pages_count': len(self.failed_pages) if hasattr(self, 'failed_pages') else 0,
             'started_at': self.started_at.isoformat() if self.started_at else None,
             'completed_at': self.completed_at.isoformat() if self.completed_at else None,
-            'created_at': self.created_at.isoformat()
+            'created_at': self.created_at.isoformat(),
+            'config': self.config
         }
 
 


### PR DESCRIPTION
- Move snippet deletion to occur only after successful extraction in result_processor.py
- Add error handling to preserve existing snippets if extraction fails
- Fix job_config not being passed through extraction worker in page_crawler.py
- Add config field to CrawlJob.to_dict() method
- Fix force regeneration to properly skip content hash check when ignore_hash=True
- Ensure metadata with ignore_hash flag is passed to page crawler for recrawls